### PR TITLE
Improve AVL API logging

### DIFF
--- a/transit_odp/api/tests/test_avl_api.py
+++ b/transit_odp/api/tests/test_avl_api.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import requests
@@ -29,6 +30,7 @@ def test_get_consumer_api_response_non_200(mrequests):
     url = "http://fakeapi.com/datafeed"
     query_params = QueryDict("originRef=12345")
     mresponse = MagicMock(spec=Response, status_code=HTTP_410_GONE)
+    mresponse.elapsed = timedelta(seconds=1)
     mrequests.get.return_value = mresponse
     actual_content, actual_status = _get_consumer_api_response(url, query_params)
     mrequests.get.assert_called_once_with(url, params=query_params, timeout=60)
@@ -45,6 +47,7 @@ def test_get_consumer_api_response(mrequests):
     mresponse = MagicMock(
         spec=Response, status_code=HTTP_200_OK, content=tostring(siri_element)
     )
+    mresponse.elapsed = timedelta(seconds=1)
     mrequests.get.return_value = mresponse
     actual_content, actual_status = _get_consumer_api_response(url, query_params)
     mrequests.get.assert_called_once_with(url, params=query_params, timeout=60)

--- a/transit_odp/api/views/avl.py
+++ b/transit_odp/api/views/avl.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -12,6 +14,8 @@ from rest_framework.response import Response
 from transit_odp.api.renders import BinRenderer, ProtoBufRenderer, XMLRender
 from transit_odp.organisation.constants import DatasetType
 from transit_odp.organisation.models import Dataset
+
+logger = logging.getLogger(__name__)
 
 API_KEY = "api_key"
 PARAMETERS = (
@@ -136,6 +140,11 @@ def _get_consumer_api_response(url: str, query_params: QueryDict):
     except RequestException:
         return content, response_status
 
+    elapsed_time = response.elapsed.total_seconds()
+    logger.info(
+        f"Request to Consumer API with params {dict(params)} took {elapsed_time}s "
+        f"- status {response.status_code}"
+    )
     if response.status_code == 200:
         content = response.content
         response_status = status.HTTP_200_OK


### PR DESCRIPTION
We are now logging the query params and the time it takes to make a request to the consumer api

*DO NOT MERGE*