### PR TITLE
BODP-5614: Review My Bus Location Data: General UI - Split text on

### DIFF
--- a/transit_odp/frontend/assets/sass/components/table/_table.scss
+++ b/transit_odp/frontend/assets/sass/components/table/_table.scss
@@ -13,7 +13,12 @@ $govuk-table-border: 1px solid $govuk-border-colour;
     font-size: 18px;
     border-top: $govuk-table-border;
     border-bottom: 0;
-    word-break: break-word;
+  }
+
+  .govuk-table__row {
+      .govuk-table__cell:last-child {
+          word-break: break-word;
+      }
   }
 
   .govuk-table__row:last-child {


### PR DESCRIPTION
Removed break-word from general table

2 bugs stories: BODP-5614, BODP-5615

![table](https://user-images.githubusercontent.com/111745616/208121963-0f7225e9-2b4d-4f24-8df5-1e860c65a81c.png)

@paul.holland