### PR TITLE
NO-TICKET: Fix SASS/CSS slash division warnings

### DIFF
--- a/transit_odp/frontend/assets/sass/patterns/_step-by-step-nav.scss
+++ b/transit_odp/frontend/assets/sass/patterns/_step-by-step-nav.scss
@@ -20,12 +20,13 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
 @mixin step-nav-line-position {
   left: 0;
-  margin-left: ($number-circle-size / 2) - ($stroke-width / 2);
+  margin-left: calc($number-circle-size / 2) - calc($stroke-width / 2);
 }
 
 @mixin step-nav-line-position-large {
   left: 0;
-  margin-left: ($number-circle-size-large / 2) - ($stroke-width-large / 2);
+  margin-left: calc($number-circle-size-large / 2) -
+    calc($stroke-width-large / 2);
   border-width: $stroke-width-large;
 }
 
@@ -153,8 +154,8 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
     z-index: 6;
     bottom: 0;
     left: 0;
-    margin-left: $number-circle-size / 4;
-    width: $number-circle-size / 2;
+    margin-left: calc($number-circle-size / 4);
+    width: calc($number-circle-size / 2);
     height: 0;
     border-bottom: solid $stroke-width
       govuk-colour("mid-grey", $legacy: "grey-2");
@@ -176,8 +177,8 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
   .app-step-nav--large & {
     @include govuk-media-query($from: tablet) {
       &:before {
-        margin-left: $number-circle-size-large / 4;
-        width: $number-circle-size-large / 2;
+        margin-left: calc($number-circle-size-large / 4);
+        width: calc($number-circle-size-large / 2);
         border-width: $stroke-width-large;
       }
 
@@ -427,9 +428,9 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
     z-index: 5;
     top: 0.6em; // position the dot to align with the first row of text in the link
     left: -(govuk-spacing(6) + govuk-spacing(3));
-    margin-top: -($stroke-width / 2);
-    margin-left: ($number-circle-size / 2);
-    width: $number-circle-size / 2;
+    margin-top: -(calc($stroke-width / 2));
+    margin-left: calc($number-circle-size / 2);
+    width: calc($number-circle-size / 2);
     height: $stroke-width;
     background: govuk-colour("black");
   }
@@ -438,7 +439,7 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
     @include govuk-media-query($from: tablet) {
       &:before {
         left: -(govuk-spacing(9));
-        margin-left: ($number-circle-size-large / 2);
+        margin-left: calc($number-circle-size-large / 2);
         height: $stroke-width-large;
       }
     }

--- a/transit_odp/frontend/assets/sass/patterns/_step-by-step-related.scss
+++ b/transit_odp/frontend/assets/sass/patterns/_step-by-step-related.scss
@@ -32,7 +32,7 @@
   }
 
   .app-step-nav-related__pretitle {
-    margin-bottom: govuk-spacing(6) / 4;
+    margin-bottom: calc(govuk-spacing(6) / 4);
   }
 }
 

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -57,7 +57,10 @@ module.exports = {
         use: [
           MiniCssExtractPlugin.loader,
           { loader: "css-loader", options: { sourceMap: true } },
-          { loader: "sass-loader", options: { sourceMap: true } },
+          {
+            loader: "sass-loader",
+            options: { sourceMap: true, sassOptions: { quietDeps: true } },
+          },
         ],
       },
       {


### PR DESCRIPTION
Updated instances of slash as division in our own .scss files with `calc()` to avoid deprecated syntax as per this [Breaking Change](https://sass-lang.com/documentation/breaking-changes/slash-div).

Added `quietDeps: True` flag to webpack to silence deprecation warnings from dependencies which were flooding docker django logs, as per [gov.uk guidance](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#silence-deprecation-warnings-from-dependencies-in-dart-sass).
