### PR TITLE
BODP-5680: Fix count of "completely matching" vehicle activity's

### DIFF
--- a/transit_odp/avl/post_publishing_checks/daily/writer.py
+++ b/transit_odp/avl/post_publishing_checks/daily/writer.py
@@ -100,7 +100,7 @@ class PostPublishingResultsJsonWriter:
                     field.count_present += 1
                     if result.matches(field.sirivm_field):
                         field.count_matches += 1
-                        if field != SirivmField.BLOCK_REF:
+                        if field.sirivm_field != SirivmField.BLOCK_REF:
                             num_matching_fields += 1
             if num_matching_fields == num_mandatory_fields:
                 self.complete_matches += 1


### PR DESCRIPTION
Also fixes BODP-5681 and BODP-5692