### PR TITLE
BODS-3 stop retry when OTC has empty response

### DIFF
--- a/transit_odp/otc/client/otc_client.py
+++ b/transit_odp/otc/client/otc_client.py
@@ -25,7 +25,7 @@ class EmptyResponseException(Exception):
     pass
 
 
-retry_exceptions = (RequestException, EmptyResponseException)
+retry_exceptions = RequestException
 
 
 class Page(BaseModel):

--- a/transit_odp/otc/loaders.py
+++ b/transit_odp/otc/loaders.py
@@ -5,6 +5,7 @@ from typing import Set, Tuple, Union
 from django.db import transaction
 
 from transit_odp.otc.client.enums import RegistrationStatusEnum
+from transit_odp.otc.client.otc_client import EmptyResponseException
 from transit_odp.otc.models import Licence, Operator, Service
 from transit_odp.otc.registry import Registry
 
@@ -168,13 +169,16 @@ class Loader:
             logger.error("Cant find last modified date in database, giving up")
             raise LoadFailedException("Cannot calculate last run date of task")
 
-        with transaction.atomic():
-            self.registry.get_variations_since(most_recently_modified.last_modified)
-            self.load_licences()
-            self.load_operators()
-            self.load_services()
-            self.update_services_and_operators()
-            self.delete_bad_data()
+        try:
+            with transaction.atomic():
+                self.registry.get_variations_since(most_recently_modified.last_modified)
+                self.load_licences()
+                self.load_operators()
+                self.load_services()
+                self.update_services_and_operators()
+                self.delete_bad_data()
+        except EmptyResponseException:
+            pass
 
     def _delete_all_otc_data(self) -> None:
         logger.info("Clearing OTC tables")


### PR DESCRIPTION
Hi @ITO-PaulHolland,
Please have a look and suggest if this is fine. 
1. I am handling the empty response at the source which marks the job as success.
2. Remove retry attempts if the response is empty.