### PR TITLE
BODP-5716: Task to advance seasonal service dates automatically

### DIFF
--- a/transit_odp/taskapp/celery.py
+++ b/transit_odp/taskapp/celery.py
@@ -152,4 +152,8 @@ class CeleryAppConfig(AppConfig):
                 + "task_weekly_assimilate_post_publishing_check_reports",
                 "schedule": crontab(day_of_week=0, hour=23, minute=0),
             },
+            "task_seasonal_service_updated_dates": {
+                "task": ADMIN_TASKS + "task_seasonal_service_updated_dates",
+                "schedule": crontab(hour=23),
+            },
         }


### PR DESCRIPTION
We will create a celery task that runs daily and checks for any seasonal services that end in the past. When this happens, the start and end date of the seasonal service will automatically be advanced by a year.

@ITO-PaulHolland @anguskbell @marcusher-ito