### PR TITLE
NO-TICKET: Fix seasonal service unit test. It tried to edit a seasonal service,

### DIFF
--- a/transit_odp/publish/tests/test_seasonal_service_views.py
+++ b/transit_odp/publish/tests/test_seasonal_service_views.py
@@ -207,6 +207,7 @@ class TestEditSeasonalServiceView:
             kwargs={"pk1": self.org.id, "pk": self.seasonal_service.id},
         )
 
+    @freeze_time("2023-01-01")
     def test_edit_seasonal_service_date(self, publish_client):
         """
         GIVEN : a new seasonal services


### PR DESCRIPTION
which failed as the new dates were now in the past, which wasn't the case at the time the unit test was written.