### PR TITLE
BODS-43 - change in logic when effective date is null for to delete services

### DIFF
--- a/transit_odp/fares/templates/fares/review/success_content.html
+++ b/transit_odp/fares/templates/fares/review/success_content.html
@@ -25,7 +25,7 @@
                             {% blocktrans %}
                                 The fares data supplied is non-compliant. You can publish this
                                 dataset now, however it is important to address the issues
-                                highightlighted in the report with your supplier. Please contact
+                                highlighted in the report with your supplier. Please contact
                                 the helpdesk if there are any items on the report which your
                                 supplier cannot help you with.
                             {% endblocktrans %}

--- a/transit_odp/otc/registry.py
+++ b/transit_odp/otc/registry.py
@@ -194,8 +194,6 @@ class Registry:
         if variation.effective_date:
             if variation.effective_date > date.today():
                 self.update(variation)
-        else:
-            self.update(variation)
 
     def update(self, registration: Registration) -> None:
         """

--- a/transit_odp/otc/registry.py
+++ b/transit_odp/otc/registry.py
@@ -155,9 +155,6 @@ class Registry:
                 not in RegistrationStatusEnum.to_change()
             ):
                 highest_variation_number = registration.variation_number
-                logger.info(
-                    f"Highest variation number is >> {highest_variation_number}"
-                )
                 return [
                     variation
                     for variation in registrations


### PR DESCRIPTION
change in logic from this:
b1) If state is ‘Revoked’, ‘CNS’, ’Admin Cancelled’, ’ New’, ’Cancelled’, ’Refused’, 'Surrendered’, and effective date is Null or > todays date then remember this service as active

to this:
b1) If state is ‘Revoked’, ‘CNS’, ’Admin Cancelled’, ’ New’, ’Cancelled’, ’Refused’, 'Surrendered’, and effective date is > todays date then remember this service as active