### PR TITLE
Update action.yml

### DIFF
--- a/.github/workflows/templates/update_task_def/action.yml
+++ b/.github/workflows/templates/update_task_def/action.yml
@@ -25,13 +25,10 @@ runs:
       shell: bash
       env:
         TASK_FAMILY: bodds_${{ inputs.service }}_${{ inputs.environment }}
-        IMAGE: ${{ inputs.image_id }}
-        CONTAINER: ${{ inputs.container }}
         CLUSTER: bodds-${{ inputs.environment }}
-        SERVICE: ${{ inputs.service }}
       run: |
-        aws ecs describe-task-definition --include TAGS --task-definition $TASK_FAMILY | jq '.taskDefinition.containerDefinitions[] |= if (.name=="$CONTAINER" ) then (.image = $IMAGE) else . end | .taskDefinition["tags"] = .tags | .taskDefinition | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatabilities) | del(.registeredAt) | del(.registeredBy) | del(.compatibilities)' > ${{ github.workspace }}/task-definition.json
+        aws ecs describe-task-definition --include TAGS --task-definition $TASK_FAMILY | jq '.taskDefinition.containerDefinitions[] |= if (.name=="${{ inputs.container }}" ) then (.image = '${{ inputs.image_id }}') else . end | .taskDefinition["tags"] = .tags | .taskDefinition | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatabilities) | del(.registeredAt) | del(.registeredBy) | del(.compatibilities)' > ${{ github.workspace }}/task-definition.json
         aws ecs register-task-definition --cli-input-json file://${{ github.workspace }}/task-definition.json
         def_arn=$( aws ecs describe-task-definition --task-definition $TASK_FAMILY --query taskDefinition.taskDefinitionArn --output text )
-        aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition $def_arn
-        aws ecs wait services-stable --cluster $CLUSTER --services $SERVICE
+        aws ecs update-service --cluster $CLUSTER --service ${{ inputs.service }} --task-definition $def_arn
+        aws ecs wait services-stable --cluster $CLUSTER --services ${{ inputs.service }}

--- a/.github/workflows/templates/update_task_def/action.yml
+++ b/.github/workflows/templates/update_task_def/action.yml
@@ -27,7 +27,7 @@ runs:
         TASK_FAMILY: bodds_${{ inputs.service }}_${{ inputs.environment }}
         CLUSTER: bodds-${{ inputs.environment }}
       run: |
-        aws ecs describe-task-definition --include TAGS --task-definition $TASK_FAMILY | jq '.taskDefinition.containerDefinitions[] |= if (.name=="${{ inputs.container }}" ) then (.image = '${{ inputs.image_id }}') else . end | .taskDefinition["tags"] = .tags | .taskDefinition | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatabilities) | del(.registeredAt) | del(.registeredBy) | del(.compatibilities)' > ${{ github.workspace }}/task-definition.json
+        aws ecs describe-task-definition --include TAGS --task-definition $TASK_FAMILY | jq '.taskDefinition.containerDefinitions[] |= if (.name=="${{ inputs.container }}" ) then (.image = "${{ inputs.image_id }}") else . end | .taskDefinition["tags"] = .tags | .taskDefinition | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatabilities) | del(.registeredAt) | del(.registeredBy) | del(.compatibilities)' > ${{ github.workspace }}/task-definition.json
         aws ecs register-task-definition --cli-input-json file://${{ github.workspace }}/task-definition.json
         def_arn=$( aws ecs describe-task-definition --task-definition $TASK_FAMILY --query taskDefinition.taskDefinitionArn --output text )
         aws ecs update-service --cluster $CLUSTER --service ${{ inputs.service }} --task-definition $def_arn


### PR DESCRIPTION
Avoid use of environment variables in single quoted string

The previous issue was caused because $IMAGE and $CONTAINER are bash env vars which are not interpolated as they are enclosed in single quotes. Reverting to using the github templating variables as they operate before the bash execution, so the issue should not occur