### PR TITLE
story/DISRUPTIONS-366 : Download all data page disruptions

### DIFF
--- a/transit_odp/browse/templates/browse/downloads.html
+++ b/transit_odp/browse/templates/browse/downloads.html
@@ -141,6 +141,33 @@
             </ul>
         </div>
     </div>
+     <div class="govuk-grid-row govuk-!-margin-top-5">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+                <a class="govuk-link" href=""
+                    onClick="">
+                    {% trans 'Disruptions data' %}
+                </a>
+            </p>
+            <p class="govuk-body">
+                {%  blocktrans %}
+                    Download disruptions data for selected regions in SIRI-SX format.
+                {%  endblocktrans %}
+            </p>
+            <ul class="govuk-list">
+                <li>
+                    <b>{% trans 'Format' %}:</b>
+                    {% trans 'SIRI-SX File' %} {% include "browse/snippets/help_modals/sirisx.html" %}
+                </li>
+                <li><b>{% trans 'File type' %}:</b> {% trans 'ZIP file' %}</li>
+                <li><b>{% trans 'Mode' %}:</b> {% trans 'Bus, Tram, Light Rail' %}</li>
+                <li>
+                    <b>{% trans 'Update frequency' %}:</b>
+                    {% trans 'Every 5 minutes Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
+                </li>
+            </ul>
+        </div>
+    </div>
 {% endblock %}
 
 {% block scripts %}

--- a/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
+++ b/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
@@ -2,22 +2,21 @@
 {% load i18n %}
 
 {% block help_heading %}
-    {% trans "SIRI-SX" %}
+{% trans "SIRI-SX" %}
 {% endblock %}
 
 {% block help_content %}
-    <p class="govuk-body">
-        {% blocktrans %}
-            The Service Interface for Real-time Information (SIRI) specifies a European
-            interface standard for exchanging information about the planned, current or
-            projected performance of real-time public transport operations between different
-            computer systems. The latest UK profile of SIRI can be found
-        {% endblocktrans %}
-    </p>
-    <p class="govuk-body">
-        {% trans 'More information on this can be ' %}
-        <a class="govuk-link" href="http://siri.org.uk/schema/schemas.htm" target="_blank">
-            {% trans 'found here' %}
-        </a>.
-    </p>
+<p class="govuk-body">
+    {% filter force_escape %}
+    {% blocktrans %}
+    The Service Interface for Real-time Information (SIRI) specifies a European
+    interface standard for exchanging information about the planned, current or
+    projected performance of real-time public transport operations between different
+    computer systems. The latest UK profile of SIRI can be found
+    {% endblocktrans %}
+    {% endfilter %}
+    <a class="govuk-link" rel="noopener noreferrer" target="_blank" href="http://siri.org.uk/schema/schemas.htm">
+        {% filter force_escape %}{% trans 'here' %}{% endfilter %}
+    </a>.
+</p>
 {% endblock %}

--- a/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
+++ b/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
@@ -1,0 +1,23 @@
+{% extends "snippets/help_modal_base.html" %}
+{% load i18n %}
+
+{% block help_heading %}
+    {% trans "SIRI-SX" %}
+{% endblock %}
+
+{% block help_content %}
+    <p class="govuk-body">
+        {% blocktrans %}
+            The Service Interface for Real-time Information (SIRI) specifies a European
+            interface standard for exchanging information about the planned, current or
+            projected performance of real-time public transport operations between different
+            computer systems. The latest UK profile of SIRI can be found
+        {% endblocktrans %}
+    </p>
+    <p class="govuk-body">
+        {% trans 'More information on this can be ' %}
+        <a class="govuk-link" href="http://siri.org.uk/schema/schemas.htm" target="_blank">
+            {% trans 'found here' %}
+        </a>.
+    </p>
+{% endblock %}


### PR DESCRIPTION
## Description
To add a link for disruptions to download data
(Note that the href to the other page will be added in another ticket)

## Testing Instructions
Navigate to Find bus open data>Download data
See if it matches wireframes and click on ? to see pop-up about siri-sx