### PR TITLE
story/DISRUPTIONS-367 : all disruptions data page

### DIFF
--- a/transit_odp/browse/templates/browse/disruptions/download_disruptions.html
+++ b/transit_odp/browse/templates/browse/disruptions/download_disruptions.html
@@ -32,7 +32,7 @@
         <li><b>{% trans 'Mode' %}:</b> {% trans 'Bus, Tram, Light Rail' %}</li>
         <li>
             <b>{% trans 'Update frequency' %}:</b>
-            {% trans 'Every 5 minutes Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
+            {% trans 'Every minute Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
         </li>
     </ul>
 {% endblock %}

--- a/transit_odp/browse/templates/browse/disruptions/download_disruptions.html
+++ b/transit_odp/browse/templates/browse/disruptions/download_disruptions.html
@@ -1,0 +1,75 @@
+{% extends 'browse/base.html' %}
+
+{% load static %}
+{% load i18n %}
+{% load breadcrumbs %}
+
+{% block title_tag %}
+    {% trans 'All fares data' %}
+{% endblock %}
+
+{% block breadcrumb.content %}
+    {{ block.super }}
+    {% breadcrumb_url 'Download All Data' 'downloads' host hosts.data %}
+    {% breadcrumb 'All Fares Data' %}
+{% endblock %}
+
+{% block heading.title.text %}{% trans 'All disruption data' %}{% endblock %}
+
+{% block secondary.title %}
+    <h3 class="govuk-heading-l">{% trans 'Download file' %}</h3>
+    <p class="govuk-body">
+        {%  blocktrans %}
+            Download a snapshot of all live and upcoming disruptions within England
+        {%  endblocktrans %}
+    </p>
+    <ul class="govuk-list">
+        <li>
+            <b>{% trans 'Format' %}:</b>
+            {% trans 'SIRI-SX File' %} {% include "browse/snippets/help_modals/sirisx.html" %}
+        </li>
+        <li><b>{% trans 'File type' %}:</b> {% trans 'ZIP file' %}</li>
+        <li><b>{% trans 'Mode' %}:</b> {% trans 'Bus, Tram, Light Rail' %}</li>
+        <li>
+            <b>{% trans 'Update frequency' %}:</b>
+            {% trans 'Every 5 minutes Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
+        </li>
+    </ul>
+{% endblock %}
+
+{% block heading.subtitle %}
+    <p class="govuk-body govuk-!-margin-bottom-0">
+        {% if show_bulk_archive_url %}
+            <a class="govuk-link" href="{% url 'downloads-disruptions-bulk' host hosts.data %}"
+                onClick="addGATagEvent()">
+                {% trans 'Download all disruption data  ' %}
+            </a>
+        {% else %}
+            {% blocktrans %}
+                Bulk download is not yet available. Please check back later.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+{% endblock %}
+
+{% block heading.secondary %}
+    {% include "browse/snippets/download_secondary_links.html" %}
+{% endblock %}
+
+{% block inner %}
+    <div class="govuk-grid-row govuk-!-margin-top-9">
+    </div>
+{% endblock %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script>
+        function addGATagEvent() {
+            gtag('event', 'Download all event', {
+                'event_category': 'link',
+                'event_label': 'bulk download disruptions',
+                'event_action': 'download'
+            });
+        }
+    </script>
+{% endblock %}

--- a/transit_odp/browse/templates/browse/downloads.html
+++ b/transit_odp/browse/templates/browse/downloads.html
@@ -141,6 +141,33 @@
             </ul>
         </div>
     </div>
+     <div class="govuk-grid-row govuk-!-margin-top-5">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+                <a class="govuk-link" href=""
+                    onClick="">
+                    {% trans 'Disruptions data' %}
+                </a>
+            </p>
+            <p class="govuk-body">
+                {%  blocktrans %}
+                    Download disruptions data for selected regions in SIRI-SX format.
+                {%  endblocktrans %}
+            </p>
+            <ul class="govuk-list">
+                <li>
+                    <b>{% trans 'Format' %}:</b>
+                    {% trans 'SIRI-SX File' %} {% include "browse/snippets/help_modals/sirisx.html" %}
+                </li>
+                <li><b>{% trans 'File type' %}:</b> {% trans 'ZIP file' %}</li>
+                <li><b>{% trans 'Mode' %}:</b> {% trans 'Bus, Tram, Light Rail' %}</li>
+                <li>
+                    <b>{% trans 'Update frequency' %}:</b>
+                    {% trans 'Every 5 minutes Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
+                </li>
+            </ul>
+        </div>
+    </div>
 {% endblock %}
 
 {% block scripts %}

--- a/transit_odp/browse/templates/browse/downloads.html
+++ b/transit_odp/browse/templates/browse/downloads.html
@@ -144,8 +144,8 @@
      <div class="govuk-grid-row govuk-!-margin-top-5">
         <div class="govuk-grid-column-two-thirds">
             <p class="govuk-body">
-                <a class="govuk-link" href=""
-                    onClick="">
+                <a class="govuk-link" href="{% url 'download-disruptions' host hosts.data %}"
+                onClick="addGATagEvent('disruptions')">
                     {% trans 'Disruptions data' %}
                 </a>
             </p>

--- a/transit_odp/browse/templates/browse/downloads.html
+++ b/transit_odp/browse/templates/browse/downloads.html
@@ -163,7 +163,7 @@
                 <li><b>{% trans 'Mode' %}:</b> {% trans 'Bus, Tram, Light Rail' %}</li>
                 <li>
                     <b>{% trans 'Update frequency' %}:</b>
-                    {% trans 'Every 5 minutes Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
+                    {% trans 'Every minute Coverage: North of England (Greater Manchester, Merseyside, South Yorkshire, North Yorkshire, Nexus) Source: Local Authority' %}
                 </li>
             </ul>
         </div>

--- a/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
+++ b/transit_odp/browse/templates/browse/snippets/help_modals/sirisx.html
@@ -1,0 +1,23 @@
+{% extends "snippets/help_modal_base.html" %}
+{% load i18n %}
+
+{% block help_heading %}
+    {% trans "SIRI-SX" %}
+{% endblock %}
+
+{% block help_content %}
+    <p class="govuk-body">
+        {% blocktrans %}
+            The Service Interface for Real-time Information (SIRI) specifies a European
+            interface standard for exchanging information about the planned, current or
+            projected performance of real-time public transport operations between different
+            computer systems. The latest UK profile of SIRI can be found
+        {% endblocktrans %}
+    </p>
+    <p class="govuk-body">
+        {% trans 'More information on this can be ' %}
+        <a class="govuk-link" href="http://siri.org.uk/schema/schemas.htm" target="_blank">
+            {% trans 'found here' %}
+        </a>.
+    </p>
+{% endblock %}

--- a/transit_odp/browse/urls/disruptions.py
+++ b/transit_odp/browse/urls/disruptions.py
@@ -1,7 +1,6 @@
 from django.urls import path
-
 from transit_odp.browse.views.disruptions_views import DownloadDisruptionsView
 
 urlpatterns = [
-    path("download/", view=DownloadDisruptionsView.as_view(), name="download-disruptions"),
+    path("download/", view=DownloadDisruptionsView.as_view(), name="download-disruptions")
 ]

--- a/transit_odp/browse/urls/disruptions.py
+++ b/transit_odp/browse/urls/disruptions.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from transit_odp.browse.views.disruptions_views import DownloadDisruptionsView
+
+urlpatterns = [
+    path("download/", view=DownloadDisruptionsView.as_view(), name="download-disruptions"),
+]

--- a/transit_odp/browse/urls/disruptions.py
+++ b/transit_odp/browse/urls/disruptions.py
@@ -2,5 +2,7 @@ from django.urls import path
 from transit_odp.browse.views.disruptions_views import DownloadDisruptionsView
 
 urlpatterns = [
-    path("download/", view=DownloadDisruptionsView.as_view(), name="download-disruptions")
+    path(
+        "download/", view=DownloadDisruptionsView.as_view(), name="download-disruptions"
+    )
 ]

--- a/transit_odp/browse/urls/root.py
+++ b/transit_odp/browse/urls/root.py
@@ -115,6 +115,7 @@ urlpatterns = [
     path("timetable/", include("transit_odp.browse.urls.timetables")),
     path("avl/", include("transit_odp.browse.urls.avl")),
     path("fares/", include("transit_odp.browse.urls.fares")),
+    path("disruptions/", include("transit_odp.browse.urls.disruptions")),
     path("account/", include("config.urls.allauth")),
     path(
         "account/",

--- a/transit_odp/browse/views/disruptions_views.py
+++ b/transit_odp/browse/views/disruptions_views.py
@@ -1,6 +1,7 @@
 from transit_odp.browse.views.base_views import BaseTemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
+
 class DownloadDisruptionsView(LoginRequiredMixin, BaseTemplateView):
     template_name = "browse/disruptions/download_disruptions.html"
 

--- a/transit_odp/browse/views/disruptions_views.py
+++ b/transit_odp/browse/views/disruptions_views.py
@@ -1,4 +1,3 @@
-from transit_odp.organisation.constants import DatasetType
 from transit_odp.browse.views.base_views import BaseTemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 

--- a/transit_odp/browse/views/disruptions_views.py
+++ b/transit_odp/browse/views/disruptions_views.py
@@ -1,0 +1,11 @@
+from transit_odp.organisation.constants import DatasetType
+from transit_odp.browse.views.base_views import BaseTemplateView
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+class DownloadDisruptionsView(LoginRequiredMixin, BaseTemplateView):
+    template_name = "browse/disruptions/download_disruptions.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        return context

--- a/transit_odp/organisation/constants.py
+++ b/transit_odp/organisation/constants.py
@@ -60,6 +60,7 @@ class DatasetType(int, ChoiceEnum):
     TIMETABLE = 1
     AVL = 2
     FARES = 3
+    DISRUPTION = 4
 
 
 TimetableType = DatasetType.TIMETABLE.value

--- a/transit_odp/organisation/constants.py
+++ b/transit_odp/organisation/constants.py
@@ -60,7 +60,6 @@ class DatasetType(int, ChoiceEnum):
     TIMETABLE = 1
     AVL = 2
     FARES = 3
-    DISRUPTION = 4
 
 
 TimetableType = DatasetType.TIMETABLE.value


### PR DESCRIPTION
## Description
To add the disruptions download page as per wireframes

actual bulk link added in another PR when the celery worker is in (in another pr)

## Testing Instructions
Navigate to Find bus open data>Download data> Disruptions data
See if it matches wireframes 