### PR TITLE
story/BODS-775: Remove servers DDL from all api types

### DIFF
--- a/transit_odp/static/openapi/avl3.yml
+++ b/transit_odp/static/openapi/avl3.yml
@@ -17,6 +17,9 @@ info:
   title: Location data API
   version: 1.0.0
 
+servers:
+  - url: "/api/v1"
+
 tags:
   - name: SIRI-VM Data feed
     description: Interact with SIRI-VM datafeeds
@@ -24,7 +27,7 @@ tags:
     description: Interact with GTFS-RT datafeeds
 
 paths:
-  /api/v1/datafeed:
+  /datafeed:
     get:
       tags:
         - SIRI-VM Data feed
@@ -106,7 +109,7 @@ paths:
         400:
           description: Invalid data supplied
 
-  /api/v1/datafeed/{datafeedID}/:
+  /datafeed/{datafeedID}/:
     get:
       tags:
         - SIRI-VM Data feed
@@ -130,7 +133,7 @@ paths:
         404:
           description: Datafeed not found
 
-  /api/v1/gtfsrtdatafeed/:
+  /gtfsrtdatafeed/:
     get:
       tags:
         - GTFS RT Data feed

--- a/transit_odp/static/openapi/fares3.yml
+++ b/transit_odp/static/openapi/fares3.yml
@@ -17,12 +17,15 @@ info:
   title: Fares data API
   version: 1.0.0
 
+servers:
+  - url: "/api/v1/fares"
+
 tags:
   - name: Data set
     description: Interact with fares datasets
 
 paths:
-  /api/v1/fares/dataset:
+  /dataset:
     get:
       tags:
         - Data set
@@ -102,7 +105,7 @@ paths:
         400:
           description: Invalid data supplied
 
-  /api/v1/fares/dataset/{datasetID}:
+  /dataset/{datasetID}:
     get:
       tags:
         - Data set

--- a/transit_odp/static/openapi/timetables3.yml
+++ b/transit_odp/static/openapi/timetables3.yml
@@ -17,12 +17,15 @@ info:
   title: Timetables data API
   version: "1.0.0"
 
+servers:
+  - url: "/api/v1"
+
 tags:
   - name: timetables
     description: Interact with timetable datasets
 
 paths:
-  /api/v1/dataset:
+  /dataset:
     get:
       tags:
         - timetables
@@ -164,7 +167,7 @@ paths:
         "400":
           description: Invalid query parameters supplied
 
-  /api/v1/dataset/{datasetID}:
+  /dataset/{datasetID}:
     get:
       tags:
         - timetables

--- a/transit_odp/templates/swagger_ui/avl.html
+++ b/transit_odp/templates/swagger_ui/avl.html
@@ -34,6 +34,9 @@
         .responses-wrapper {
             display: none;
         }
+        .scheme-container{
+            display: none;
+        }
     </style>
     <script>
         // Function to show the response section
@@ -68,7 +71,7 @@
                     });
                 });
             }
-            
+
         }
 
         $(document).ready(function () {

--- a/transit_odp/templates/swagger_ui/fares.html
+++ b/transit_odp/templates/swagger_ui/fares.html
@@ -34,6 +34,9 @@
         .responses-wrapper {
             display: none;
         }
+        .scheme-container{
+            display: none;
+        }
     </style>
     <script>
         // Function to show the response section
@@ -69,7 +72,7 @@
                     });
                 });
             }
-            
+
         }
 
         $(document).ready(function () {

--- a/transit_odp/templates/swagger_ui/timetables.html
+++ b/transit_odp/templates/swagger_ui/timetables.html
@@ -34,6 +34,9 @@
         .responses-wrapper {
             display: none;
         }
+        .scheme-container{
+            display: none;
+        }
     </style>
     <script>
         // Function to show the response section
@@ -69,7 +72,7 @@
                     });
                 });
             }
-            
+
         }
 
         $(document).ready(function () {


### PR DESCRIPTION
Made a code change to match the design - currently on dev:

<img width="552" alt="image" src="https://github.com/department-for-transport-BODS/bods/assets/75623814/1a62dab1-445d-4092-9f08-3f9d8c4feb16">

Now will match design to be:

<img width="465" alt="image" src="https://github.com/department-for-transport-BODS/bods/assets/75623814/7046e0b4-ff3d-4bb6-8981-3210bcc239a3">
