### PR TITLE
fix to display correct value matching the report status

### DIFF
--- a/transit_odp/api/serializers/__init__.py
+++ b/transit_odp/api/serializers/__init__.py
@@ -131,6 +131,7 @@ class DatasetSerializer(serializers.Serializer):
 
     def get_score(self, feed):
         value = feed.score if feed.score else 0
+        value = int(value * 1000) / 1000.0
         return f"{value*100:.1f}%"
 
     def get_RAG(self, feed):

--- a/transit_odp/api/serializers/__init__.py
+++ b/transit_odp/api/serializers/__init__.py
@@ -131,6 +131,9 @@ class DatasetSerializer(serializers.Serializer):
 
     def get_score(self, feed):
         value = feed.score if feed.score else 0
+        # To overcome an issue where 0.999
+        # is rounded to 1 which inturn returns
+        # 100% instead of 99.9%
         value = int(value * 1000) / 1000.0
         return f"{value*100:.1f}%"
 

--- a/transit_odp/api/serializers/__init__.py
+++ b/transit_odp/api/serializers/__init__.py
@@ -134,7 +134,7 @@ class DatasetSerializer(serializers.Serializer):
         # To overcome an issue where 0.999
         # is rounded to 1 which inturn returns
         # 100% instead of 99.9%
-        if 0.99 < value < 1:
+        if 0.999 < value < 1:
             value = int(value * 1000) / 1000.0
         return f"{value*100:.1f}%"
 

--- a/transit_odp/api/serializers/__init__.py
+++ b/transit_odp/api/serializers/__init__.py
@@ -134,7 +134,8 @@ class DatasetSerializer(serializers.Serializer):
         # To overcome an issue where 0.999
         # is rounded to 1 which inturn returns
         # 100% instead of 99.9%
-        value = int(value * 1000) / 1000.0
+        if 0.99 < value < 1:
+            value = int(value * 1000) / 1000.0
         return f"{value*100:.1f}%"
 
     def get_RAG(self, feed):

--- a/transit_odp/api/tests/test_timetables_api.py
+++ b/transit_odp/api/tests/test_timetables_api.py
@@ -19,6 +19,8 @@ pytestmark = pytest.mark.django_db
         (1, "100.0%", "green"),
         (0.33, "33.0%", "red"),
         (0.90005, "90.0%", "red"),
+        (0.9999, "99.9%", "amber"),
+        (0.005, "0.5%", "red"),
     ),
 )
 def test_dq_rag(client_factory, user_factory, score, percent, rag):


### PR DESCRIPTION
The fix should not round values above 0.995 to 1 there by returning 99.5% instead of 100%