### PR TITLE
fix to use sequence number for stops from xml file

### DIFF
--- a/transit_odp/pipelines/pipelines/dataset_etl/utils/loaders.py
+++ b/transit_odp/pipelines/pipelines/dataset_etl/utils/loaders.py
@@ -145,9 +145,12 @@ def add_service_pattern_to_service_pattern_stops(
                 record["service_pattern_id"], level="service_pattern_id"
             ).iloc[0]["id"]
             vehicle_journey_id = record.get("id", None)
+            sequence_number = record["sequence_number"]
+            if not sequence_number:
+                sequence_number = record["order"]
             yield ServicePatternStop(
                 service_pattern_id=service_pattern_id,
-                sequence_number=record["order"],
+                sequence_number=sequence_number,
                 naptan_stop_id=record["naptan_id"],
                 atco_code=record["stop_atco"],
                 departure_time=record["departure_time"],

--- a/transit_odp/pipelines/pipelines/dataset_etl/utils/transform.py
+++ b/transit_odp/pipelines/pipelines/dataset_etl/utils/transform.py
@@ -47,6 +47,7 @@ def create_stop_sequence(df: pd.DataFrame) -> pd.DataFrame:
         "from_stop_atco",
         "departure_time",
         "is_timing_status",
+        "from_stop_sequence_number",
     ]
 
     if "vehicle_journey_code" in df.columns:
@@ -64,7 +65,14 @@ def create_stop_sequence(df: pd.DataFrame) -> pd.DataFrame:
         )
 
     stops_atcos = (
-        df[first_stop_columns].iloc[[0]].rename(columns={"from_stop_atco": "stop_atco"})
+        df[first_stop_columns]
+        .iloc[[0]]
+        .rename(
+            columns={
+                "from_stop_atco": "stop_atco",
+                "from_stop_sequence_number": "sequence_number",
+            }
+        )
     )
     is_flexible_departure_time = False
     # Departure time for flexible stops is null
@@ -81,6 +89,7 @@ def create_stop_sequence(df: pd.DataFrame) -> pd.DataFrame:
         use_vehicle_journey_runtime = True
         columns = [
             "to_stop_atco",
+            "to_stop_sequence_number",
             "is_timing_status",
             "run_time",
             "wait_time",
@@ -90,6 +99,7 @@ def create_stop_sequence(df: pd.DataFrame) -> pd.DataFrame:
     else:
         columns = [
             "to_stop_atco",
+            "to_stop_sequence_number",
             "is_timing_status",
             "run_time",
             "wait_time",
@@ -100,7 +110,12 @@ def create_stop_sequence(df: pd.DataFrame) -> pd.DataFrame:
 
     columns_to_drop = ["run_time", "wait_time"]
     # Extract all remaining stop to be placed below the principal stop
-    last_stop = df[columns].rename(columns={"to_stop_atco": "stop_atco"})
+    last_stop = df[columns].rename(
+        columns={
+            "to_stop_atco": "stop_atco",
+            "to_stop_sequence_number": "sequence_number",
+        }
+    )
     columns.remove("to_stop_atco")
     columns.remove("is_timing_status")
     # Calculate departure time for standard stops where run_time is found in VehicleJourney
@@ -172,6 +187,7 @@ def transform_service_pattern_stops(
 
 def agg_service_pattern_sequences(df: pd.DataFrame):
     geometry = None
+    df = df.drop_duplicates(subset=["sequence_number"])
     points = df["geometry"].values
     if len(list(point for point in points if point)) > 1:
         geometry = LineString(
@@ -317,9 +333,16 @@ def create_route_links(timing_links, stop_points):
             "is_timing_status",
             "run_time",
             "wait_time",
+            "from_stop_sequence_number",
+            "to_stop_sequence_number",
         ]
     else:
-        columns = ["from_stop_ref", "to_stop_ref"]
+        columns = [
+            "from_stop_ref",
+            "to_stop_ref",
+            "from_stop_sequence_number",
+            "to_stop_sequence_number",
+        ]
 
     route_links = (
         timing_links.reset_index()
@@ -772,6 +795,8 @@ def transform_service_pattern_to_service_links(
             "order",
             "from_stop_atco",
             "to_stop_atco",
+            "from_stop_sequence_number",
+            "to_stop_sequence_number",
             "departure_time",
             "is_timing_status",
             "run_time",
@@ -790,6 +815,8 @@ def transform_service_pattern_to_service_links(
             "order",
             "from_stop_atco",
             "to_stop_atco",
+            "from_stop_sequence_number",
+            "to_stop_sequence_number",
             "departure_time",
             "is_timing_status",
             "run_time",
@@ -818,6 +845,12 @@ def transform_flexible_service_pattern_to_service_links(flexible_service_pattern
     service_pattern_to_service_links["is_timing_status"] = False
     service_pattern_to_service_links["run_time"] = pd.NaT
     service_pattern_to_service_links["wait_time"] = pd.NaT
+    service_pattern_to_service_links[
+        "from_stop_sequence_number"
+    ] = service_pattern_to_service_links["order"]
+    service_pattern_to_service_links["to_stop_sequence_number"] = (
+        service_pattern_to_service_links["order"] + 1
+    )
     service_pattern_to_service_links = service_pattern_to_service_links.set_index(
         ["file_id", "service_pattern_id", "order"]
     )

--- a/transit_odp/pipelines/tests/test_dataset_etl/test_extract_metadata.py
+++ b/transit_odp/pipelines/tests/test_dataset_etl/test_extract_metadata.py
@@ -328,7 +328,7 @@ class ExtractMetadataTestCase(ExtractBaseTestCase):
         )
 
         # assert timing_links
-        self.assertEqual(extracted.timing_links.shape, (20, 8))
+        self.assertEqual(extracted.timing_links.shape, (20, 10))
         self.assertCountEqual(
             list(extracted.timing_links.columns),
             [
@@ -340,6 +340,8 @@ class ExtractMetadataTestCase(ExtractBaseTestCase):
                 "is_timing_status",
                 "run_time",
                 "wait_time",
+                "from_stop_sequence_number",
+                "to_stop_sequence_number",
             ],
         )
         self.assertEqual(
@@ -465,7 +467,7 @@ class ExtractMetadataTestCase(ExtractBaseTestCase):
         )
 
         # assert timing_links
-        self.assertEqual(extracted.timing_links.shape, (20, 8))
+        self.assertEqual(extracted.timing_links.shape, (20, 10))
         self.assertCountEqual(
             list(extracted.timing_links.columns),
             [
@@ -477,6 +479,8 @@ class ExtractMetadataTestCase(ExtractBaseTestCase):
                 "is_timing_status",
                 "run_time",
                 "wait_time",
+                "from_stop_sequence_number",
+                "to_stop_sequence_number",
             ],
         )
         self.assertEqual(
@@ -596,6 +600,8 @@ class ExtractMetadataTestCase(ExtractBaseTestCase):
                 "vehicle_journey_code",
                 "journey_code",
                 "order",
+                "from_stop_sequence_number",
+                "to_stop_sequence_number",
             ],
         )
 
@@ -846,6 +852,7 @@ class ExtractUtilitiesTestCase(TestCase):
                     "geometry": None,
                     "locality_id": 1,
                     "admin_area_id": 1,
+                    "sequence_number": 0,
                 },
                 {
                     "file_id": 4288313304800897227,
@@ -856,6 +863,7 @@ class ExtractUtilitiesTestCase(TestCase):
                     "geometry": None,
                     "locality_id": 1,
                     "admin_area_id": 1,
+                    "sequence_number": 1,
                 },
                 {
                     "file_id": 4288313304800897227,
@@ -866,6 +874,7 @@ class ExtractUtilitiesTestCase(TestCase):
                     "geometry": None,
                     "locality_id": 1,
                     "admin_area_id": 1,
+                    "sequence_number": 2,
                 },
             ]
         )

--- a/transit_odp/pipelines/tests/test_dataset_etl/test_flexible_stops.py
+++ b/transit_odp/pipelines/tests/test_dataset_etl/test_flexible_stops.py
@@ -133,6 +133,7 @@ class ExtractFlexibleStops(ExtractBaseTestCase):
                     "locality_id",
                     "admin_area_id",
                     "common_name",
+                    "sequence_number",
                 ]
             ),
         )

--- a/transit_odp/timetables/dataframes.py
+++ b/transit_odp/timetables/dataframes.py
@@ -352,8 +352,12 @@ def journey_pattern_sections_to_dataframe(sections):
             id_ = section["id"]
             links = section.get_elements(["JourneyPatternTimingLink"])
             for order, link in enumerate(links):
-                from_stop_ref = link.get_element(["From", "StopPointRef"]).text
-                to_stop_ref = link.get_element(["To", "StopPointRef"]).text
+                from_stop = link.get_element(["From"])
+                to_stop = link.get_element(["To"])
+                from_stop_sequence_number = from_stop.get("SequenceNumber")
+                to_stop_sequence_number = to_stop.get("SequenceNumber")
+                from_stop_ref = from_stop.get_element(["StopPointRef"]).text
+                to_stop_ref = to_stop.get_element(["StopPointRef"]).text
                 to_stop_timing_status = link.get_element_or_none(["To", "TimingStatus"])
                 is_timing_status = False
                 if to_stop_timing_status and to_stop_timing_status.text in [
@@ -386,6 +390,8 @@ def journey_pattern_sections_to_dataframe(sections):
                         "order": order,
                         "from_stop_ref": from_stop_ref,
                         "to_stop_ref": to_stop_ref,
+                        "from_stop_sequence_number": from_stop_sequence_number,
+                        "to_stop_sequence_number": to_stop_sequence_number,
                         "is_timing_status": is_timing_status,
                         "run_time": run_time,
                         "wait_time": wait_time,


### PR DESCRIPTION
Contains below fixes:

- Read sequence number for stops from journey pattern sections
- Load map without circular data