### PR TITLE
Call DQS via. State Machine execution

### DIFF
--- a/.github/workflows/unit_test_execution_pr.yml
+++ b/.github/workflows/unit_test_execution_pr.yml
@@ -277,7 +277,7 @@ jobs:
         id: run_tests
         run: |
           pip install --upgrade typing-extensions
-          pytest -vv --junitxml=junit_report.xml || [ $? = 1 ]
+          pytest -n auto -vv --junitxml=junit_report.xml || [ $? = 1 ]
 
       - name: Pytest coverage comment
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
     rev: 7.1.0
     hooks:
       - id: flake8
+        args:
+          - --max-line-length=130
+          - --extend-ignore=F841
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.13.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: flake8
         args:
           - --max-line-length=130
-          - --extend-ignore=F841
+          - --extend-ignore=F841,E203
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.13.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,15 @@ Restore the db after the service is up using the below command.
 make local-db-restore
 ```
 
+## Feature flags
+
+BODS uses Django Waffle to dynamically set feature flags to toggle behaviour on or off, or test new functionality.
+Within the admin page under [waffle flags](http://admin.localhost:8000/admin/waffle/flag) you can set these flags on or off.
+At the time of writing it's advisable to create at least the following 2 flags and set them for "everyone":
+
+- is_new_gtfs_api_active
+- is_new_data_quality_service_active
+
 ## OTC Dataset
 
 BODS utilises the Office of Traffic Commissioners Bus Service dataset for

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -645,6 +645,9 @@ S3_BUCKET_DQS_CSV_REPORT = env(
     "S3_BUCKET_DQS_CSV_REPORT",
     default="bodds-dev-dqs-reports",
 )
+# DQS STEP FUNCTION PARAMETERS
+STATE_MACHINE_ARN = env("STATE_MACHINE_ARN", default="")
+
 # SQS QUEUE
 # ------------------------------------------------------------------------------
 SQS_QUEUE_ENDPOINT_URL = env(
@@ -653,6 +656,7 @@ SQS_QUEUE_ENDPOINT_URL = env(
 AWS_REGION_NAME = env("AWS_REGION_NAME", default="eu-west-2")
 AWS_ACCESS_KEY_ID = env("AWS_ACCESS_KEY_ID", default="test")
 AWS_SECRET_ACCESS_KEY = env("AWS_SECRET_ACCESS_KEY", default="test")
+AWS_SESSION_TOKEN = env("AWS_SESSION_TOKEN", default="test")
 AWS_ENVIRONMENT = env("AWS_ENVIRONMENT", default="LOCAL")
 
 # ABODS AVL LINE LEVEL DETAILS

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,6 +67,10 @@ services:
       - redis
       - postgres
     ports: []
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
     command: /start-celeryworker
 
   celerybeat:

--- a/docker/production/django/Dockerfile
+++ b/docker/production/django/Dockerfile
@@ -19,8 +19,11 @@ ENV PYTHONUNBUFFERED=1 \
 ENV PATH=$PATH:/app/node_modules/.bin
 WORKDIR /app
 
-RUN echo deb http://ftp.uk.debian.org/debian unstable main contrib non-free >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -y \
+RUN echo deb http://ftp.uk.debian.org/debian unstable main contrib non-free >> /etc/apt/sources.list &&  \
+    echo 'Acquire::http::Timeout "10";' >> /etc/apt/apt.conf.d/80-connection && \
+    echo 'Acquire::ftp::Timeout "10";' >> /etc/apt/apt.conf.d/80-connection && \
+    echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/80-connection && \
+    apt-get update && apt-get install -y \
             libgdal-dev \
             g++ \
             proj-bin \
@@ -46,7 +49,6 @@ RUN apt-get update && apt-get install -y \
             setuptools \
             wheel \
             cython
-
 
 # Install python packages
 # Copy the compiled frontend from step 1 - this ensures production image

--- a/transit_odp/common/utils/aws_common.py
+++ b/transit_odp/common/utils/aws_common.py
@@ -26,6 +26,46 @@ def get_s3_bucket_storage() -> object:
         raise
 
 
+class StepFunctionsClientWrapper:
+
+    def __init__(self):
+        try:
+            self.endpoint_url = settings.STEP_FUNCTIONS_ENDPOINT_URL
+
+            if settings.AWS_ENVIRONMENT == "LOCAL":
+                self.sm_client = boto3.client(
+                    "stepfunctions",
+                    endpoint_url=self.endpoint_url,
+                    region_name=settings.AWS_REGION_NAME,
+                    aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                )
+            else:
+                self.sm_client = boto3.client(
+                    "stepfunctions",
+                    endpoint_url=self.endpoint_url,
+                )
+        except Exception as e:
+            logger.info(
+                f"DQS-StepFunctions:General exception when initialising Step Functions client wrapper: {e}"
+            )
+            raise
+
+    def start_execution(self, state_machine_arn: str, input: dict, name: str) -> str:
+        """
+        Start a Step Functions execution and return the execution ARN.
+        """
+        try:
+            response = self.sm_client.start_execution(
+                stateMachineArn=state_machine_arn, input=json.dumps(input), name=name
+            )
+            return response["executionArn"]
+        except Exception as e:
+            logger.info(
+                f"DQS-StepFunctions:General exception when starting Step Functions execution: {e}"
+            )
+            raise
+
 class SQSClientWrapper:
     """Initialize SQS client, get queue names and send messages to the queues"""
 

--- a/transit_odp/common/utils/aws_common.py
+++ b/transit_odp/common/utils/aws_common.py
@@ -27,27 +27,25 @@ def get_s3_bucket_storage() -> object:
 
 
 class StepFunctionsClientWrapper:
+
     def __init__(self):
         try:
-            self.endpoint_url = settings.STEP_FUNCTIONS_ENDPOINT_URL
 
             if settings.AWS_ENVIRONMENT == "LOCAL":
                 self.sm_client = boto3.client(
                     "stepfunctions",
-                    endpoint_url=self.endpoint_url,
                     region_name=settings.AWS_REGION_NAME,
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                    aws_session_token=settings.AWS_SESSION_TOKEN,
                 )
             else:
-                self.sm_client = boto3.client(
-                    "stepfunctions",
-                    endpoint_url=self.endpoint_url,
-                )
+                self.sm_client = boto3.client("stepfunctions")
         except Exception as e:
             logger.info(
                 f"DQS-StepFunctions:General exception when initialising Step Functions client wrapper: {e}"
             )
+            logger.exception(e)
             raise
 
     def start_execution(self, state_machine_arn: str, input: dict, name: str) -> str:

--- a/transit_odp/common/utils/aws_common.py
+++ b/transit_odp/common/utils/aws_common.py
@@ -1,9 +1,9 @@
-import logging
 import json
+import logging
 
+import boto3
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
-import boto3
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,6 @@ def get_s3_bucket_storage() -> object:
 
 
 class StepFunctionsClientWrapper:
-
     def __init__(self):
         try:
             self.endpoint_url = settings.STEP_FUNCTIONS_ENDPOINT_URL
@@ -65,6 +64,7 @@ class StepFunctionsClientWrapper:
                 f"DQS-StepFunctions:General exception when starting Step Functions execution: {e}"
             )
             raise
+
 
 class SQSClientWrapper:
     """Initialize SQS client, get queue names and send messages to the queues"""
@@ -142,7 +142,8 @@ class SQSClientWrapper:
 
                                 for error in response_send_messages.get("Failed", []):
                                     logger.info(
-                                        f"DQS-SQS:Failed to send message to {queue_url}: {error['MessageId'] if 'MessageId' in error else error['Id']} - {error['Message']}"
+                                        f"DQS-SQS:Failed to send message to {queue_url}: "
+                                        f"{error['MessageId'] if 'MessageId' in error else error['Id']} - {error['Message']}"
                                     )
                         except Exception as e:
                             logger.error(

--- a/transit_odp/common/utils/aws_common.py
+++ b/transit_odp/common/utils/aws_common.py
@@ -27,10 +27,8 @@ def get_s3_bucket_storage() -> object:
 
 
 class StepFunctionsClientWrapper:
-
     def __init__(self):
         try:
-
             if settings.AWS_ENVIRONMENT == "LOCAL":
                 self.sm_client = boto3.client(
                     "stepfunctions",

--- a/transit_odp/timetables/tasks.py
+++ b/transit_odp/timetables/tasks.py
@@ -575,7 +575,7 @@ def task_data_quality_service(revision_id: int, task_id: int) -> int:
             queues_payload = create_queue_payload(pending_checks)
             sqs_queue_client = SQSClientWrapper()
             sqs_queue_client.send_message_to_queue(queues_payload)
-            adapter.info("DQS-SQS:SQS queue messsages sent successfully.")
+            adapter.info("DQS-SQS:SQS queue messages sent successfully.")
 
     except (DatabaseError, IntegrityError) as db_exc:
         task.handle_general_pipeline_exception(

--- a/transit_odp/timetables/tasks.py
+++ b/transit_odp/timetables/tasks.py
@@ -19,7 +19,10 @@ from transit_odp.common.loggers import (
     get_dataset_adapter_from_revision,
 )
 from transit_odp.common.utils import sha1sum
-from transit_odp.common.utils.aws_common import SQSClientWrapper, StepFunctionsClientWrapper
+from transit_odp.common.utils.aws_common import (
+    SQSClientWrapper,
+    StepFunctionsClientWrapper,
+)
 from transit_odp.common.utils.s3_bucket_connection import (
     get_file_name_by_id,
     read_datasets_file_from_s3,
@@ -540,15 +543,19 @@ def task_data_quality_service(revision_id: int, task_id: int) -> int:
             revision.id
         )
         if settings.USE_STATE_MACHINE_FOR_DQS == "TRUE":
-            adapter.info(f"Using state machine to run checks on {len(txc_file_attributes_objects)} files")
+            adapter.info(
+                f"Using state machine to run checks on {len(txc_file_attributes_objects)} files"
+            )
+            step_function_client = StepFunctionsClientWrapper()
             for file in txc_file_attributes_objects:
-                step_function_client = StepFunctionsClientWrapper()
                 execution_arn = step_function_client.start_execution(
                     state_machine_arn=settings.STATE_MACHINE_ARN,
                     input=dict(file_id=file.id),
-                    name=f"DQSExecutionForRevision{file.id}"
+                    name=f"DQSExecutionForRevision{file.id}",
                 )
-                adapter.info(f"Began State Machine Execution for {file.id}: {execution_arn}")
+                adapter.info(
+                    f"Began State Machine Execution for {file.id}: {execution_arn}"
+                )
         else:
             combinations = itertools.product(txc_file_attributes_objects, checks)
             TaskResults.initialize_task_results(report, combinations)

--- a/transit_odp/timetables/tasks.py
+++ b/transit_odp/timetables/tasks.py
@@ -527,6 +527,10 @@ def task_dqs_upload(revision_id: int, task_id: int):
 
 @shared_task()
 def task_data_quality_service(revision_id: int, task_id: int) -> int:
+    is_using_step_function_for_dqs = flag_is_active(
+        "", "is_using_step_function_for_dqs"
+    )
+
     """A task that runs the DQS checks on TxC file(s)."""
     task = get_etl_task_or_pipeline_exception(task_id)
     revision = task.revision
@@ -542,7 +546,7 @@ def task_data_quality_service(revision_id: int, task_id: int) -> int:
         txc_file_attributes_objects = TXCFileAttributes.objects.for_revision(
             revision.id
         )
-        if settings.USE_STATE_MACHINE_FOR_DQS == "TRUE":
+        if is_using_step_function_for_dqs:
             adapter.info(
                 f"Using state machine to run checks on {len(txc_file_attributes_objects)} files"
             )

--- a/transit_odp/timetables/tests/test_tasks.py
+++ b/transit_odp/timetables/tests/test_tasks.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from django.core.files import File
@@ -20,11 +20,13 @@ from transit_odp.organisation.factories import (
     OrganisationFactory,
     TXCFileAttributesFactory,
 )
+from transit_odp.organisation.models import TXCFileAttributes
 from transit_odp.pipelines.exceptions import PipelineException
 from transit_odp.pipelines.factories import DatasetETLTaskResultFactory
 from transit_odp.pipelines.models import DatasetETLTaskResult
 from transit_odp.timetables.constants import PII_ERROR
 from transit_odp.timetables.tasks import (
+    task_data_quality_service,
     task_dataset_download,
     task_dataset_etl,
     task_post_schema_check,
@@ -34,6 +36,7 @@ from transit_odp.timetables.tasks import (
     task_timetable_schema_check,
 )
 from transit_odp.timetables.transxchange import BaseSchemaViolation
+from transit_odp.transmodel.factories import ServiceFactory
 from transit_odp.users.factories import OrgAdminFactory
 from transit_odp.validate import DownloadException, FileScanner
 from transit_odp.validate.antivirus import AntiVirusError, SuspiciousFile
@@ -382,7 +385,8 @@ def test_run_task_post_schema_check(mocker, tmp_path, mock_post_schema_validator
     testzip = tmp_path / "test_pii.zip"
     create_text_file(
         file1,
-        r'<TransXChange FileName="C:\Users\test\Documents\Marshalls of Sutton 2021-01-08 15-54\Marshalls of Sutton 55 2021-01-08 15-54.xml"></TransXChange>',
+        r'<TransXChange FileName="C:\Users\test\Documents\Marshalls of Sutton 2021-01-08 '
+        r'15-54\Marshalls of Sutton 55 2021-01-08 15-54.xml"></TransXChange>',
     )
     create_zip_file(testzip, [file1])
     with open(testzip, "rb") as zout:
@@ -439,7 +443,8 @@ def test_run_task_post_schema_check_exception(
     testzip = tmp_path / "test_pii.zip"
     create_text_file(
         file1,
-        r'<TransXChange FileName="C:\Users\test\Documents\Marshalls of Sutton 2021-01-08 15-54\Marshalls of Sutton 55 2021-01-08 15-54.xml">',
+        r'<TransXChange FileName="C:\Users\test\Documents\Marshalls of Sutton 2021-01-08 '
+        r'15-54\Marshalls of Sutton 55 2021-01-08 15-54.xml">',
     )
     create_zip_file(testzip, [file1])
     with open(testzip, "rb") as zout:
@@ -572,3 +577,74 @@ def test_task_dataset_etl_exception():
         task_dataset_etl(revision.id, task.id)
     task.refresh_from_db()
     assert task.error_code == task.NO_VALID_FILE_TO_PROCESS
+
+
+@patch("transit_odp.timetables.tasks.SQSClientWrapper")
+@patch("transit_odp.timetables.tasks.flag_is_active")
+def test_task_data_quality_service_with_sqs(
+    mock_flag_is_active, mock_sqs_client_wrapper
+):
+    upload_file_path = DATA / "3_pti_pass.zip"
+
+    mock_flag_is_active.return_value = False
+    client = mock_sqs_client_wrapper.return_value
+
+    dataset = DatasetFactory(live_revision=None)
+    revision = add_draft_revision(
+        dataset,
+        txc_version=2.2,
+        upload_file__from_path=upload_file_path,
+        status=FeedStatus.indexing.value,
+    )
+    attr = TXCFileAttributesFactory(revision=revision)
+    ServiceFactory(revision=revision, txcfileattributes=attr)
+
+    revision = dataset.revisions.first()
+    task = revision.etl_results.first()
+
+    task_data_quality_service(revision.id, task.id)
+
+    task.refresh_from_db()
+    assert mock_sqs_client_wrapper.called
+    assert client.send_message_to_queue.called
+    client.send_message_to_queue.assert_called_once()
+    assert task.error_code == ""
+
+
+@patch("transit_odp.timetables.tasks.StepFunctionsClientWrapper")
+@patch("transit_odp.timetables.tasks.flag_is_active")
+def test_task_data_quality_service_with_step_function(
+    mock_flag_is_active, mock_step_function_client_wrapper
+):
+    upload_file_path = DATA / "3_pti_pass.zip"
+    arn = "arn:aws:states:eu-west-2:228266753808:stateMachine:dqs-dev-DQSStateMachine"
+
+    mock_flag_is_active.return_value = True
+    client = mock_step_function_client_wrapper.return_value
+
+    dataset = DatasetFactory(live_revision=None)
+    revision = add_draft_revision(
+        dataset,
+        txc_version=2.2,
+        upload_file__from_path=upload_file_path,
+        status=FeedStatus.indexing.value,
+    )
+    attr = TXCFileAttributesFactory(revision=revision)
+    ServiceFactory(revision=revision, txcfileattributes=attr)
+
+    revision = dataset.revisions.first()
+    task = revision.etl_results.first()
+
+    task_data_quality_service(None, task.id)
+
+    task.refresh_from_db()
+    assert mock_step_function_client_wrapper.called
+    assert client.start_execution.called
+    client.start_execution.assert_called_once
+    for file in TXCFileAttributes.objects.for_revision(revision.id):
+        client.start_execution.assert_called_with(
+            state_machine_arn=arn,
+            input=dict(file_id=file.id),
+            name=f"DQSExecutionForRevision{file.id}",
+        )
+    assert task.error_code == ""


### PR DESCRIPTION
One of 2 PRs to attempt to aleviate the servicepatternstop scan volume as discussed by re-arranging the lambdas into a step function/state machine. The lambdas in DQS will execute either from the SQS or State Machine trigger and should operate in the same way regardless. They will utilise an S3 bucket to cache results (only one call cached at the moment) from the DB which will be cleaned up after a week.

The bods PR utilises a waffle feature flag (is_using_step_function_for_dqs) to switch between using SQS or the state machine, so both PRs should in theory be mergeable without altering the behaviour and then waffle can be used to enable the step function.

Posting here for information, happy to make the update in necessary tickets, boards, documentation etc as I've worked at pace I don't know which ticket this pertains to. Posting both PRs here for visibility, both in draft currently until we're ready to merge to dev.

https://github.com/department-for-transport-BODS/data-quality-service/pull/16
https://github.com/department-for-transport-BODS/bods/pull/1845