### PR TITLE
fix: IAVL - pass through requestor ref

### DIFF
--- a/transit_odp/avl/client/cavl.py
+++ b/transit_odp/avl/client/cavl.py
@@ -38,10 +38,11 @@ class CAVLService(ICAVLService):
         password: str,
         description: str,
         short_description: str,
+        requestor_ref: Optional[str] = None,
     ) -> bool:
         api_url = self.AVL_PRODUCER_URL + "/subscriptions"
 
-        post = {
+        body = {
             "subscriptionId": str(feed_id),
             "publisherId": str(publisher_id),
             "dataProducerEndpoint": url,
@@ -51,9 +52,12 @@ class CAVLService(ICAVLService):
             "shortDescription": short_description,
         }
 
+        if requestor_ref:
+            body["requestorRef"] = requestor_ref
+
         try:
             response = requests.post(
-                api_url, json=post, timeout=30, headers=self.headers
+                api_url, json=body, timeout=30, headers=self.headers
             )
             response.raise_for_status()
         except RequestException as e:
@@ -82,6 +86,7 @@ class CAVLService(ICAVLService):
         password: str,
         description: str,
         short_description: str,
+        requestor_ref: Optional[str] = None,
     ) -> bool:
         api_url = self.AVL_PRODUCER_URL + f"/subscriptions/{feed_id}"
 
@@ -92,6 +97,9 @@ class CAVLService(ICAVLService):
             "description": description,
             "shortDescription": short_description,
         }
+
+        if requestor_ref:
+            body["requestorRef"] = requestor_ref
 
         try:
             response = requests.put(

--- a/transit_odp/avl/client/interface.py
+++ b/transit_odp/avl/client/interface.py
@@ -13,6 +13,7 @@ class ICAVLService(Protocol):
         password: str,
         description: str,
         short_description: str,
+        requestor_ref: str,
     ) -> bool:
         """
         Registers a feed in the AVL service.
@@ -24,6 +25,7 @@ class ICAVLService(Protocol):
             password: The data producers password
             description: Description of the data feed (entered by user)
             short_description: Short description of the data feed (entered by user)
+            requestor_ref: RequestorRef for the data feed (entered by user)
 
         Returns: Boolean indicating the feed was added successfully
         """
@@ -47,6 +49,7 @@ class ICAVLService(Protocol):
         password: str,
         description: str,
         short_description: str,
+        requestor_ref: str,
     ) -> bool:
         """
         Updates an existing feed in the CAVL service.
@@ -57,6 +60,7 @@ class ICAVLService(Protocol):
             password: The data producers password
             description: Description of the data feed (entered by user)
             short_description: Short description of the data feed (entered by user)
+            requestor_ref: RequestorRef for the data feed (entered by user)
 
         Returns:
         """

--- a/transit_odp/avl/client/tests/test_cavl_client.py
+++ b/transit_odp/avl/client/tests/test_cavl_client.py
@@ -115,6 +115,7 @@ class TestCAVLService:
                 password="dummy_p",
                 description="dummy_description",
                 short_description="dummy_short_description",
+                requestor_ref="dummy_requestor_ref",
             )
 
         assert [rec.message for rec in caplog.records] == expected_message
@@ -230,7 +231,9 @@ class TestCAVLService:
         kwargs["m"].put(url, json=response_mock, status_code=status)
 
         with expected_result:
-            cavl_service.update_feed(1, "dummy", "dummy", "dummy", "dummy", "dummy")
+            cavl_service.update_feed(
+                1, "dummy", "dummy", "dummy", "dummy", "dummy", "dummy"
+            )
 
         assert [rec.message for rec in caplog.records] == expected_message
 

--- a/transit_odp/organisation/models/data.py
+++ b/transit_odp/organisation/models/data.py
@@ -391,6 +391,7 @@ class DatasetRevision(
                         password=self.password,
                         description=self.description,
                         short_description=self.short_description,
+                        requestor_ref=self.requestor_ref,
                     )
                 else:
                     cavl_service.update_feed(
@@ -400,6 +401,7 @@ class DatasetRevision(
                         password=self.password,
                         description=self.description,
                         short_description=self.short_description,
+                        requestor_ref=self.requestor_ref,
                     )
             # TODO - should likely fold the logic in 'update_live_revision' receiver
             # into this method, i.e. update live_revision on the dataset to point to

--- a/transit_odp/organisation/tests/test_models.py
+++ b/transit_odp/organisation/tests/test_models.py
@@ -206,6 +206,7 @@ class TestDatasetRevision:
             password="password123",
             description="test-description",
             short_description="test--short-description",
+            requestor_ref="test-requestor-ref",
         )
         cavl_service = mocker.patch(f"{self.mut}.CAVLService").return_value
         revision.publish()
@@ -217,6 +218,7 @@ class TestDatasetRevision:
             password="password123",
             description="test-description",
             short_description="test--short-description",
+            requestor_ref="test-requestor-ref",
         )
 
     def test_avl_dataset_publish_update_cavl(self, mocker):
@@ -230,6 +232,7 @@ class TestDatasetRevision:
                 password="password123",
                 description="test-description",
                 short_description="test-short-description",
+                requestor_ref="test-requestor-ref",
             )
 
         new_revision = AVLDatasetRevisionFactory(
@@ -240,6 +243,7 @@ class TestDatasetRevision:
             password="password123.v2",
             description="test-description2",
             short_description="test--short-description2",
+            requestor_ref="test-requestor-ref",
         )
 
         cavl_service = mocker.patch(f"{self.mut}.CAVLService").return_value
@@ -251,6 +255,7 @@ class TestDatasetRevision:
             password="password123.v2",
             description="test-description2",
             short_description="test--short-description2",
+            requestor_ref="test-requestor-ref",
         )
 
     def test_revision_draft_url_for_new_dataset(self):


### PR DESCRIPTION
This PR is a bug fix to ensure that when publishing a new AVL feed or updating an existing AVL that the form field "RequestorRef" is passed through to the IAVL service if it is provided.