### PR TITLE
ci(PgMigrationStep): Removed schema init; Pull from SSM

### DIFF
--- a/.github/workflows/cavl_deployment.yml
+++ b/.github/workflows/cavl_deployment.yml
@@ -179,19 +179,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/cavl_deployment.yml
+++ b/.github/workflows/cavl_deployment.yml
@@ -25,7 +25,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   cavl_deployment:
     name: 'cavl_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/datadog_apm_pipeline.yml
+++ b/.github/workflows/datadog_apm_pipeline.yml
@@ -19,7 +19,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   hotfix_deployment:
     name: 'datadog_apm_pipeline'
     runs-on: ubuntu-latest

--- a/.github/workflows/datadog_apm_pipeline.yml
+++ b/.github/workflows/datadog_apm_pipeline.yml
@@ -144,19 +144,24 @@ jobs:
         environment: ${{ env.ENVIRONMENT_NAME }}
         image_id: ${{ steps.check-image.outputs.image }}
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -212,25 +212,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Move secret to json payload
-      id: create-json
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: "credentials.json"
-        json: ${{ secrets.PG_MUTATION_DEV }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke --function-name bodds-${{ env.ENVIRONMENT_NAME }}-pg-mutate-lambda --payload file://credentials.json out --log-type Tail \
-        --query 'LogResult' --output text --cli-binary-format raw-in-base64-out | base64 --decode
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -19,17 +19,17 @@ defaults:
 env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
   ECR_BASE_REPOSITORY_NAME: ${{ secrets.ECR_BASE_REPOSITORY }}
+  ENVIRONMENT_NAME: dev
   AWS_REGION: ${{ vars.AWS_REGION }}
-  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ secrets.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
-  PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   dev_deployment:
     name: 'dev_deployment'
     runs-on: ubuntu-latest
-    environment: dev
-    env:
-      ENVIRONMENT_NAME: dev
+    environment:
+      name: dev
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
-        role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
         role-session-name: testAWSCLISession
         role-duration-seconds: 3600
         role-skip-session-tagging: true

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -24,7 +24,6 @@ env:
   PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
-
   dev_deployment:
     name: 'dev_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/hotfix_deployment.yml
+++ b/.github/workflows/hotfix_deployment.yml
@@ -166,19 +166,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/hotfix_deployment.yml
+++ b/.github/workflows/hotfix_deployment.yml
@@ -20,7 +20,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   hotfix_deployment:
     if: github.ref_name == 'main'
     name: 'hotfix_deployment'

--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -24,7 +24,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   prod_deployment:
     name: 'prod_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/prod_deployment.yml
+++ b/.github/workflows/prod_deployment.yml
@@ -149,19 +149,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/prod_rollback_deployment.yml
+++ b/.github/workflows/prod_rollback_deployment.yml
@@ -23,7 +23,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   prod_deployment:
     name: 'prod_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/prod_rollback_deployment.yml
+++ b/.github/workflows/prod_rollback_deployment.yml
@@ -148,19 +148,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/rerun_dev_deployment.yml
+++ b/.github/workflows/rerun_dev_deployment.yml
@@ -13,8 +13,8 @@ env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
   ENVIRONMENT_NAME: dev
   AWS_REGION: ${{ vars.AWS_REGION }}
-  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ secrets.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
-  PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   rerun_dev_deployment:
@@ -96,7 +96,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
-        role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
         role-session-name: testAWSCLISession
         role-duration-seconds: 3600
         role-skip-session-tagging: true

--- a/.github/workflows/rerun_dev_deployment.yml
+++ b/.github/workflows/rerun_dev_deployment.yml
@@ -175,18 +175,26 @@ jobs:
         ecs-services: '["celeryflower", "celeryworker", "celerybeat", "frontend", "api_frontend", "api_frontend_internal" ]'
         retries: 5
         verbose: true
+
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
 
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke --function-name bodds-${{ env.ENVIRONMENT_NAME }}-pg-mutate-lambda --payload file://credentials.json out --log-type Tail \
-        --query 'LogResult' --output text --cli-binary-format raw-in-base64-out | base64 --decode
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/rerun_dev_deployment.yml
+++ b/.github/workflows/rerun_dev_deployment.yml
@@ -13,11 +13,10 @@ env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
   ENVIRONMENT_NAME: dev
   AWS_REGION: ${{ vars.AWS_REGION }}
-  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
-  AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ secrets.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
-
   rerun_dev_deployment:
     name: 'rerun_dev_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/rerun_test_deployment.yml
+++ b/.github/workflows/rerun_test_deployment.yml
@@ -13,8 +13,8 @@ env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
   ENVIRONMENT_NAME: test
   AWS_REGION: ${{ vars.AWS_REGION }}
-  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
-  AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   rerun_test_deployment:
@@ -27,14 +27,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Configure AWS credentials
+    # Configure AWS credentials against the BODS Shared-Services Account
+    - name: Configure AWS credentials in Shared-Services
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ env.AWS_REGION }}
-        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_ASSUME_ROLE_NAME }}
+        role-to-assume: ${{ env.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
         role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
         role-duration-seconds: 3600
         role-skip-session-tagging: true
+
+    # Assume a role into the BODS-PROD account
+    - name: Configure AWS Credentials in bodds-prod
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.PROD_ASSUME_ROLE_ARN }}
+        role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        role-chaining: true
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -66,6 +78,28 @@ jobs:
     - name: Logout of Amazon ECR
       if: always()
       run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+    # Configure AWS credentials against the BODS Shared-Services Account
+    - name: Configure AWS credentials in Shared-Services
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+        role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        unset-current-credentials: true
+
+    # Now assume a role in the Environemnt Specific Account
+    - name: Configure AWS Credentials in the environment specific account
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ vars.AWS_REGION }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+        role-session-name: testAWSCLISession
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        role-chaining: true
 
     - name: Update celeryflower Task
       uses: "./.github/workflows/templates/update_task_def"

--- a/.github/workflows/rerun_test_deployment.yml
+++ b/.github/workflows/rerun_test_deployment.yml
@@ -141,19 +141,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke \
-        --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} \
-        response.json
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/rerun_test_deployment.yml
+++ b/.github/workflows/rerun_test_deployment.yml
@@ -17,7 +17,6 @@ env:
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
 jobs:
-
   rerun_test_deployment:
     name: 'rerun_test_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/run_pg_migration_task/action.yml
+++ b/.github/workflows/templates/run_pg_migration_task/action.yml
@@ -2,9 +2,9 @@ name: update_task_definition
 
 # Were we can define the inputs that our action will accept
 inputs:
-  security_groups: 
-    required: true
   environment:
+    required: true
+  security_groups: 
     required: true
   subnets:
     required: true
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
 
-  - name: Run PG migration task
+  - name: Run PG Migration Task
     shell: bash
     run: |
       run_result=$(aws ecs run-task \

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -23,9 +23,7 @@ env:
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
   AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
 
-
 jobs:
-
   test_deployment:
     name: 'test_deployment'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -18,30 +18,42 @@ defaults:
 
 env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
-  ENVIRONMENT_NAME: test
+  ENVIRONMENT_NAME: dev
   AWS_REGION: ${{ vars.AWS_REGION }}
-  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
-  AWS_ASSUME_ROLE_NAME: ${{ vars.AWS_ASSUME_ROLE_NAME }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   test_deployment:
     name: 'test_deployment'
     runs-on: ubuntu-latest
-    environment:
+    environment: 
       name: test
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Configure AWS credentials
+    # Configure AWS credentials against the BODS Shared-Services Account
+    - name: Configure AWS credentials in Shared-Services
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ env.AWS_REGION }}
-        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.AWS_ASSUME_ROLE_NAME }}
+        role-to-assume: ${{ env.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
         role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
         role-duration-seconds: 3600
         role-skip-session-tagging: true
+
+    # Assume a role into the BODS-PROD account
+    - name: Configure AWS Credentials in bodds-prod
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.PROD_ASSUME_ROLE_ARN }}
+        role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        role-chaining: true
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -74,6 +86,28 @@ jobs:
     - name: Logout of Amazon ECR
       if: always()
       run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+    # Configure AWS credentials against the BODS Shared-Services Account
+    - name: Configure AWS credentials in Shared-Services
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+        role-session-name: ${{ env.ENVIRONMENT_NAME }}-deployment
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        unset-current-credentials: true
+
+    # Now assume a role in the Environemnt Specific Account
+    - name: Configure AWS Credentials in the environment specific account
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ vars.AWS_REGION }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+        role-session-name: testAWSCLISession
+        role-duration-seconds: 3600
+        role-skip-session-tagging: true
+        role-chaining: true
 
     - name: Update celeryflower Task
       uses: "./.github/workflows/templates/update_task_def"

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -150,24 +150,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Move secret to json payload
-      id: create-json
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: "credentials.json"
-  
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke --function-name bodds_pg_mutate_lambda_test --payload file://credentials.json out --log-type Tail \
-        --query 'LogResult' --output text --cli-binary-format raw-in-base64-out | base64 --decode
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/uat_deployment.yml
+++ b/.github/workflows/uat_deployment.yml
@@ -20,8 +20,8 @@ env:
   ECR_REPOSITORY_NAME: ${{ secrets.ECR_REPOSITORY }}
   ENVIRONMENT_NAME: uat
   AWS_REGION: ${{ vars.AWS_REGION }}
-  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ secrets.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
-  PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
+  BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   uat_deployment:
@@ -103,7 +103,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
-        role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
         role-session-name: testAWSCLISession
         role-duration-seconds: 3600
         role-skip-session-tagging: true
@@ -293,7 +293,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
-        role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
+        role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
         role-session-name: testAWSCLISession
         role-duration-seconds: 3600
         role-skip-session-tagging: true

--- a/.github/workflows/uat_deployment.yml
+++ b/.github/workflows/uat_deployment.yml
@@ -183,25 +183,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Move secret to json payload
-      id: create-json
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: "credentials.json"
-        json: ${{ secrets.PG_MUTATION_UAT }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke --function-name bodds-${{ env.ENVIRONMENT_NAME }}-pg-mutate-lambda --payload file://credentials.json out --log-type Tail \
-        --query 'LogResult' --output text --cli-binary-format raw-in-base64-out | base64 --decode
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1
@@ -374,25 +373,24 @@ jobs:
         retries: 5
         verbose: true
 
+    - name: Obtain SSM parameters for pg migration
+      id: params
+      shell: bash
+      run: |
+        security_group_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/pg-migration-sg-ids" \
+          | jq -r '.Parameter.Value'`
+        subnet_ids=`aws ssm get-parameter --name "/bodds/${{ env.ENVIRONMENT_NAME }}/private-subnets" \
+          | jq -r '.Parameter.Value'`
+
+        echo "SECURITY_GROUPS=${security_group_ids}" >> "$GITHUB_OUTPUT"
+        echo "SUBNETS=${subnet_ids}" >> "$GITHUB_OUTPUT"
+
     - name: Run pg migration
       uses: "./.github/workflows/templates/run_pg_migration_task"
       with:
-        subnets: ${{ secrets.SUBNETS }}
-        security_groups: ${{ secrets.SECURITY_GROUPS }}
+        subnets: ${{ steps.params.outputs.SUBNETS }}
+        security_groups: ${{ steps.params.outputs.SECURITY_GROUPS }}
         environment: ${{ env.ENVIRONMENT_NAME }}
-
-    - name: Move secret to json payload
-      id: create-json
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: "credentials.json"
-        json: ${{ secrets.PG_MUTATION_DEV }}
-
-    - name: Invoke Lambda Function
-      shell: bash
-      run: |
-        aws lambda invoke --function-name bodds_pg_mutate_lambda_${{ env.ENVIRONMENT_NAME }} --payload file://credentials.json out --log-type Tail \
-        --query 'LogResult' --output text --cli-binary-format raw-in-base64-out | base64 --decode
 
     - name: Update Confluence Page
       uses: robsteel24/update-confluence@v1

--- a/.github/workflows/uat_deployment.yml
+++ b/.github/workflows/uat_deployment.yml
@@ -24,7 +24,6 @@ env:
   PROD_ASSUME_ROLE_ARN: ${{ secrets.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
-
   uat_deployment:
     name: 'uat_deployment'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Obtain pg_migration subnet IDs and security group IDs from SSM rather than relying on GH Secrets (static)
Removed the pg_mutate step which is only used on db instantiation for schema changes; ongoing changes should be managed by Django