### PR TITLE
BODS-7438 decrease search term length to 2

### DIFF
--- a/transit_odp/frontend/assets/js/autocomplete.js
+++ b/transit_odp/frontend/assets/js/autocomplete.js
@@ -133,7 +133,7 @@ export class AutoCompleteSearch {
   search(searchTerm) {
     this.removeSuggestions();
 
-    if (!searchTerm || searchTerm.length < 3) {
+    if (!searchTerm || searchTerm.length < 2) {
       return false;
     }
 


### PR DESCRIPTION
This will affect operator search, LTA search, org search, and all other places where `AutoCompleteSearch` class is used.