### PR TITLE
Resolves issue of email notifications going out from bods for inactiv…

### DIFF
--- a/.github/workflows/all_branches.yml
+++ b/.github/workflows/all_branches.yml
@@ -26,7 +26,7 @@ jobs:
       - name: black
         uses: psf/black@stable
         with:
-          options: "--check --config .black.toml"
+          options: "--check --diff --config .black.toml"
           src: "."
           version: "22.3.0"
 

--- a/transit_odp/organisation/querysets.py
+++ b/transit_odp/organisation/querysets.py
@@ -682,6 +682,7 @@ class DatasetQuerySet(models.QuerySet):
                 )
             )
             .exclude(effective_status__in=exclude_status)
+            .exclude(live_revision__status__in=exclude_status)
         )
         if dataset_type is not None:
             qs = qs.filter(dataset_type=dataset_type)

--- a/transit_odp/organisation/tests/test_querysets.py
+++ b/transit_odp/organisation/tests/test_querysets.py
@@ -453,6 +453,25 @@ class TestDatasetQuerySet:
         assert len(qs) == 1
         assert qs[0].id == datasets[0].id
 
+    def test_get_inactive_reprocessed(self):
+        """Tests queryset is filtered to exclude datasets that were live when
+        reprocessed but subsequently set to inactive"""
+        datasets = DatasetFactory.create_batch(3, live_revision=None)
+        DatasetRevisionFactory(
+            dataset=datasets[0], is_published=True, status=FeedStatus.live.value,
+        )
+        DatasetRevisionFactory(
+            dataset=datasets[1], is_published=True, status=FeedStatus.inactive.value,
+                status_before_reprocessing=FeedStatus.live.value
+        )
+        DatasetRevisionFactory(
+            dataset=datasets[2], is_published=True, status=FeedStatus.inactive.value,
+            status_before_reprocessing=FeedStatus.inactive.value
+        )
+        qs = Dataset.objects.get_active()
+        assert len(qs) == 1
+        assert qs[0].id == datasets[0].id
+
     def test_get_only_active_datasets_bulk_archive(self):
         """
         Tests queryset is filtered to exclude datasets which have an inactive status

--- a/transit_odp/organisation/tests/test_querysets.py
+++ b/transit_odp/organisation/tests/test_querysets.py
@@ -458,15 +458,21 @@ class TestDatasetQuerySet:
         reprocessed but subsequently set to inactive"""
         datasets = DatasetFactory.create_batch(3, live_revision=None)
         DatasetRevisionFactory(
-            dataset=datasets[0], is_published=True, status=FeedStatus.live.value,
+            dataset=datasets[0],
+            is_published=True,
+            status=FeedStatus.live.value,
         )
         DatasetRevisionFactory(
-            dataset=datasets[1], is_published=True, status=FeedStatus.inactive.value,
-                status_before_reprocessing=FeedStatus.live.value
+            dataset=datasets[1],
+            is_published=True,
+            status=FeedStatus.inactive.value,
+            status_before_reprocessing=FeedStatus.live.value,
         )
         DatasetRevisionFactory(
-            dataset=datasets[2], is_published=True, status=FeedStatus.inactive.value,
-            status_before_reprocessing=FeedStatus.inactive.value
+            dataset=datasets[2],
+            is_published=True,
+            status=FeedStatus.inactive.value,
+            status_before_reprocessing=FeedStatus.inactive.value,
         )
         qs = Dataset.objects.get_active()
         assert len(qs) == 1


### PR DESCRIPTION
…e datasets that were reprocessed when the dataset was active

<img width="1263" height="877" alt="Screenshot 2026-01-21 at 15 43 01" src="https://github.com/user-attachments/assets/9d8cee65-8c47-4f34-a776-91d85483a8c2" />

Same set of three tests fail now as did for https://github.com/department-for-transport-BODS/bods/pull/2325 in Dec:
test_get_latest_variations_since_returns_all_service_types
test_one_email_is_sent_if_deleter_is_updated
test_feed_is_successfully_deleted
