### PR TITLE
DBODS-1337: optimise draft feed query and add concurrent dataset index

### DIFF
--- a/transit_odp/organisation/migrations/0079_add_dataset_org_type_idx.py
+++ b/transit_odp/organisation/migrations/0079_add_dataset_org_type_idx.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("organisation", "0078_datasetrevision_deletion_started_at_and_more"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="dataset",
+            index=models.Index(
+                fields=["organisation", "dataset_type"],
+                name="org_dataset_org_type_idx",
+            ),
+        ),
+    ]

--- a/transit_odp/organisation/querysets.py
+++ b/transit_odp/organisation/querysets.py
@@ -543,8 +543,6 @@ class DatasetQuerySet(models.QuerySet):
                     b."short_description" as short_description,
                     b."published_at" as published_at
                         FROM "organisation_dataset"
-                    JOIN "organisation_organisation"
-                        ON ("organisation_dataset"."organisation_id" = %s)
                     CROSS JOIN LATERAL (SELECT *
                        FROM "organisation_datasetrevision"
                         WHERE ("organisation_datasetrevision".is_published = False)
@@ -553,7 +551,8 @@ class DatasetQuerySet(models.QuerySet):
                          and ("organisation_datasetrevision".status != 'expired')
                          and ("organisation_datasetrevision".is_deleted = False)
                         ) b
-                    WHERE ("organisation_dataset".dataset_type = %s)
+                    WHERE ("organisation_dataset"."organisation_id" = %s)
+                    AND ("organisation_dataset".dataset_type = %s)
                     GROUP BY "organisation_dataset"."modified", "organisation_dataset"."created", "organisation_dataset".id, b."id", b."status", b.name, b.first_expiring_service, b.num_of_lines, b.short_description, b.published_at
                     ORDER BY "organisation_dataset"."modified" DESC, "organisation_dataset"."created" DESC
 


### PR DESCRIPTION
What changed

- Removed the redundant organisation join from the draft feed raw SQL and filtered directly by organisation_id and dataset_type.
- Added a new non-atomic migration with a concurrent composite index on organisation_dataset (organisation_id, dataset_type).