### PR TITLE
Disable antivirus

### DIFF
--- a/config/.env.local.template
+++ b/config/.env.local.template
@@ -48,6 +48,8 @@ GOV_NOTIFY_API_KEY=
 # -----------------------------------------------------------------------------
 CLAMAV_HOST=clamav
 CLAMAV_PORT=3310
+# Set to True to bypass the ClamAV virus scan on uploads (local dev only).
+DISABLE_ANTIVIRUS_CHECK=False
 
 # Data Quality Service
 # ------------------------------------------------------------------------------

--- a/config/.env.local.template
+++ b/config/.env.local.template
@@ -50,6 +50,8 @@ CLAMAV_HOST=clamav
 CLAMAV_PORT=3310
 # Set to True to bypass the ClamAV virus scan on uploads (local dev only).
 DISABLE_ANTIVIRUS_CHECK=False
+# Set to True to bypass the DQS check submission (local dev only, no SQS/StepFunctions).
+DISABLE_DQS_CHECK=False
 
 # Data Quality Service
 # ------------------------------------------------------------------------------

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -494,6 +494,8 @@ DQS_WAIT_TIMEOUT = env("DQS_WAIT_TIMEOUT", cast=int, default=2160)  # minutes
 # -----------------------------------------------------------------------------
 CLAMAV_HOST = env("CLAMAV_HOST", default="clamav")
 CLAMAV_PORT = env.int("CLAMAV_PORT", default=3310)
+# Local dev escape hatch: skip virus scan entirely (e.g. when ClamAV is rate-limited).
+DISABLE_ANTIVIRUS_CHECK = env.bool("DISABLE_ANTIVIRUS_CHECK", default=False)
 
 
 # Internal settings

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -496,7 +496,8 @@ CLAMAV_HOST = env("CLAMAV_HOST", default="clamav")
 CLAMAV_PORT = env.int("CLAMAV_PORT", default=3310)
 # Local dev escape hatch: skip virus scan entirely (e.g. when ClamAV is rate-limited).
 DISABLE_ANTIVIRUS_CHECK = env.bool("DISABLE_ANTIVIRUS_CHECK", default=False)
-
+# Local dev escape hatch: skip DQS submission (SQS / Step Functions unavailable).
+DISABLE_DQS_CHECK = env.bool("DISABLE_DQS_CHECK", default=False)
 
 # Internal settings
 # ------------------------------------------------------------------------------

--- a/transit_odp/timetables/tasks.py
+++ b/transit_odp/timetables/tasks.py
@@ -544,6 +544,12 @@ def task_data_quality_service(revision_id: int, task_id: int) -> int:
     revision = task.revision
     adapter = get_dataset_adapter_from_revision(logger=logger, revision=revision)
     adapter.info("Starting DQS checks initiation task.")
+
+    if getattr(settings, "DISABLE_DQS_CHECK", False):
+        adapter.warning("DQS: SKIPPED (DISABLE_DQS_CHECK is enabled).")
+        task.update_progress(95)
+        return revision_id
+
     try:
         task.update_progress(95)
         if is_using_step_function_for_dqs:

--- a/transit_odp/validate/antivirus.py
+++ b/transit_odp/validate/antivirus.py
@@ -4,6 +4,7 @@ from typing import BinaryIO, Optional
 
 from clamd import BufferTooLongError, ClamdNetworkSocket
 from clamd import ConnectionError as ClamdConnectionError
+from django.conf import settings
 from tenacity import (
     before_log,
     retry,
@@ -88,6 +89,12 @@ class FileScanner:
         Args:
             file_: File being scanned
         """
+        if getattr(settings, "DISABLE_ANTIVIRUS_CHECK", False):
+            logger.warning(
+                "Antivirus scan: SKIPPED (DISABLE_ANTIVIRUS_CHECK is enabled)."
+            )
+            return
+
         try:
             result = self._perform_scan(file_)
         except ClamdConnectionError as exc:


### PR DESCRIPTION
## Summary

Adds two env-driven local-dev escape hatches so BODS can be run locally when external services (ClamAV, DQS / Step Functions) are unreachable or rate-limited. Both flags default to `False`, so behaviour in every deployed environment is unchanged.

## Changes

- **`DISABLE_ANTIVIRUS_CHECK`** — when `True`, `FileScanner.scan()` short-circuits with a warning instead of calling ClamAV.
- **`DISABLE_DQS_CHECK`** — when `True`, `task_data_quality_service` skips DQS initiation, marks the task 95% complete, and returns.
- Both read via `env.bool(..., default=False)` and documented in `.env.local.template`.

## Notes for reviewer

Split out from DBODS-2249 at review request — no functional change to any production path.